### PR TITLE
Exchange Asset

### DIFF
--- a/application_manager_v2/.openapi-generator/FILES
+++ b/application_manager_v2/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 .travis.yml
 README.md
 api/openapi.yaml
@@ -79,5 +78,4 @@ model_sidecars.go
 model_state.go
 model_target.go
 response.go
-test/api_default_test.go
 utils.go

--- a/exchange_assets/api/openapi.yaml
+++ b/exchange_assets/api/openapi.yaml
@@ -751,6 +751,7 @@ components:
         classifier:
           description: The type of the asset to be created
           enum:
+          - mule-application
           - raml-fragment
           - raml
           - oas
@@ -809,12 +810,10 @@ components:
           title: assetLink
           type: string
       required:
-      - apiVersion
       - asset
       - assetId
       - classifier
       - groupId
-      - main
       - name
       - organizationId
       - version

--- a/exchange_assets/api_default.go
+++ b/exchange_assets/api_default.go
@@ -387,11 +387,11 @@ type DefaultApiAssetsPostRequest struct {
 	version *string
 	name *string
 	classifier *string
-	apiVersion *string
-	main *string
 	groupId *string
 	asset *os.File
 	xAllowedApiSpecFormats *string
+	apiVersion *string
+	main *string
 	dependencies *string
 	originalFormatVersion *string
 	metadata *string
@@ -435,18 +435,6 @@ func (r DefaultApiAssetsPostRequest) Classifier(classifier string) DefaultApiAss
 	return r
 }
 
-// The product version of API assets. Required for \\\&quot;raml\\\&quot;, \\\&quot;oas\\\&quot;, \\\&quot;wsdl\\\&quot; and \\\&quot;http\\\&quot; assets
-func (r DefaultApiAssetsPostRequest) ApiVersion(apiVersion string) DefaultApiAssetsPostRequest {
-	r.apiVersion = &apiVersion
-	return r
-}
-
-// The main file of the asset. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;.
-func (r DefaultApiAssetsPostRequest) Main(main string) DefaultApiAssetsPostRequest {
-	r.main = &main
-	return r
-}
-
 // The id of the business group the asset will belong to
 func (r DefaultApiAssetsPostRequest) GroupId(groupId string) DefaultApiAssetsPostRequest {
 	r.groupId = &groupId
@@ -462,6 +450,18 @@ func (r DefaultApiAssetsPostRequest) Asset(asset *os.File) DefaultApiAssetsPostR
 // Specify API Spec formats that assets are allowed to use
 func (r DefaultApiAssetsPostRequest) XAllowedApiSpecFormats(xAllowedApiSpecFormats string) DefaultApiAssetsPostRequest {
 	r.xAllowedApiSpecFormats = &xAllowedApiSpecFormats
+	return r
+}
+
+// The product version of API assets. Required for \\\&quot;raml\\\&quot;, \\\&quot;oas\\\&quot;, \\\&quot;wsdl\\\&quot; and \\\&quot;http\\\&quot; assets
+func (r DefaultApiAssetsPostRequest) ApiVersion(apiVersion string) DefaultApiAssetsPostRequest {
+	r.apiVersion = &apiVersion
+	return r
+}
+
+// The main file of the asset. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;.
+func (r DefaultApiAssetsPostRequest) Main(main string) DefaultApiAssetsPostRequest {
+	r.main = &main
 	return r
 }
 
@@ -552,12 +552,6 @@ func (a *DefaultApiService) AssetsPostExecute(r DefaultApiAssetsPostRequest) (*P
 	if r.classifier == nil {
 		return localVarReturnValue, nil, reportError("classifier is required and must be specified")
 	}
-	if r.apiVersion == nil {
-		return localVarReturnValue, nil, reportError("apiVersion is required and must be specified")
-	}
-	if r.main == nil {
-		return localVarReturnValue, nil, reportError("main is required and must be specified")
-	}
 	if r.groupId == nil {
 		return localVarReturnValue, nil, reportError("groupId is required and must be specified")
 	}
@@ -591,8 +585,12 @@ func (a *DefaultApiService) AssetsPostExecute(r DefaultApiAssetsPostRequest) (*P
 	parameterAddToHeaderOrQuery(localVarFormParams, "version", r.version, "")
 	parameterAddToHeaderOrQuery(localVarFormParams, "name", r.name, "")
 	parameterAddToHeaderOrQuery(localVarFormParams, "classifier", r.classifier, "")
-	parameterAddToHeaderOrQuery(localVarFormParams, "apiVersion", r.apiVersion, "")
-	parameterAddToHeaderOrQuery(localVarFormParams, "main", r.main, "")
+	if r.apiVersion != nil {
+		parameterAddToHeaderOrQuery(localVarFormParams, "apiVersion", r.apiVersion, "")
+	}
+	if r.main != nil {
+		parameterAddToHeaderOrQuery(localVarFormParams, "main", r.main, "")
+	}
 	parameterAddToHeaderOrQuery(localVarFormParams, "groupId", r.groupId, "")
 	var assetLocalVarFormFileName string
 	var assetLocalVarFileName     string

--- a/exchange_assets/docs/DefaultApi.md
+++ b/exchange_assets/docs/DefaultApi.md
@@ -236,7 +236,7 @@ Name | Type | Description  | Notes
 
 ## AssetsPost
 
-> PostAssetResponse AssetsPost(ctx).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).ApiVersion(apiVersion).Main(main).GroupId(groupId).Asset(asset).XAllowedApiSpecFormats(xAllowedApiSpecFormats).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
+> PostAssetResponse AssetsPost(ctx).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).GroupId(groupId).Asset(asset).XAllowedApiSpecFormats(xAllowedApiSpecFormats).ApiVersion(apiVersion).Main(main).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
 
 Create a new asset
 
@@ -261,11 +261,11 @@ func main() {
     version := "version_example" // string | The version of the asset being created (must follow Semver syntax)
     name := "name_example" // string | The visible name of the asset
     classifier := "classifier_example" // string | The type of the asset to be created
-    apiVersion := "apiVersion_example" // string | The product version of API assets. Required for \\\"raml\\\", \\\"oas\\\", \\\"wsdl\\\" and \\\"http\\\" assets
-    main := "main_example" // string | The main file of the asset. Required for \\\"raml\\\", \\\"raml-fragment\\\", \\\"oas\\\" and \\\"wsdl\\\".
     groupId := "groupId_example" // string | The id of the business group the asset will belong to
     asset := os.NewFile(1234, "some_file") // *os.File | The asset file. Required for \\\"raml\\\", \\\"raml-fragment\\\", \\\"oas\\\" and \\\"wsdl\\\". Maximum size of 5 MB. This field must be the last field of the multipart.
     xAllowedApiSpecFormats := "xAllowedApiSpecFormats_example" // string | Specify API Spec formats that assets are allowed to use (optional)
+    apiVersion := "apiVersion_example" // string | The product version of API assets. Required for \\\"raml\\\", \\\"oas\\\", \\\"wsdl\\\" and \\\"http\\\" assets (optional)
+    main := "main_example" // string | The main file of the asset. Required for \\\"raml\\\", \\\"raml-fragment\\\", \\\"oas\\\" and \\\"wsdl\\\". (optional)
     dependencies := "dependencies_example" // string | Required for \\\"api-group\\\" classifier only, They are APIs included in it, as a JSON array of objects. Because the field must be of String type, the stringified value of the JSON array must be passed as parameter. (optional)
     originalFormatVersion := "originalFormatVersion_example" // string | The version of the format of the api specification. ie ‘2.0’ for OAS 2.0 (optional)
     metadata := "metadata_example" // string | A design center object describing asset projectId, branchId and commitId. Because the field must be of String type, the stringified value of the JSON object must be passed as parameter. (optional)
@@ -274,7 +274,7 @@ func main() {
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.DefaultApi.AssetsPost(context.Background()).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).ApiVersion(apiVersion).Main(main).GroupId(groupId).Asset(asset).XAllowedApiSpecFormats(xAllowedApiSpecFormats).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
+    resp, r, err := apiClient.DefaultApi.AssetsPost(context.Background()).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).GroupId(groupId).Asset(asset).XAllowedApiSpecFormats(xAllowedApiSpecFormats).ApiVersion(apiVersion).Main(main).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.AssetsPost``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -301,11 +301,11 @@ Name | Type | Description  | Notes
  **version** | **string** | The version of the asset being created (must follow Semver syntax) | 
  **name** | **string** | The visible name of the asset | 
  **classifier** | **string** | The type of the asset to be created | 
- **apiVersion** | **string** | The product version of API assets. Required for \\\&quot;raml\\\&quot;, \\\&quot;oas\\\&quot;, \\\&quot;wsdl\\\&quot; and \\\&quot;http\\\&quot; assets | 
- **main** | **string** | The main file of the asset. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. | 
  **groupId** | **string** | The id of the business group the asset will belong to | 
  **asset** | ***os.File** | The asset file. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. Maximum size of 5 MB. This field must be the last field of the multipart. | 
  **xAllowedApiSpecFormats** | **string** | Specify API Spec formats that assets are allowed to use | 
+ **apiVersion** | **string** | The product version of API assets. Required for \\\&quot;raml\\\&quot;, \\\&quot;oas\\\&quot;, \\\&quot;wsdl\\\&quot; and \\\&quot;http\\\&quot; assets | 
+ **main** | **string** | The main file of the asset. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. | 
  **dependencies** | **string** | Required for \\\&quot;api-group\\\&quot; classifier only, They are APIs included in it, as a JSON array of objects. Because the field must be of String type, the stringified value of the JSON array must be passed as parameter. | 
  **originalFormatVersion** | **string** | The version of the format of the api specification. ie ‘2.0’ for OAS 2.0 | 
  **metadata** | **string** | A design center object describing asset projectId, branchId and commitId. Because the field must be of String type, the stringified value of the JSON object must be passed as parameter. | 

--- a/rtf/.openapi-generator/FILES
+++ b/rtf/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 .travis.yml
 README.md
 api/openapi.yaml
@@ -51,5 +50,4 @@ model_ingress.go
 model_post_fabrics_404_response.go
 model_status.go
 response.go
-test/api_default_test.go
 utils.go


### PR DESCRIPTION
The exchange_assets post method incorrectly requires apiVersion and main - which are not required for all classifier types i.e. mule-application which @matthewdevenny added to the list of classifier enums

See Anypoint CLI example
https://help.salesforce.com/s/articleView?id=001119648&type=1

https://docs.mulesoft.com/anypoint-cli/latest/exchange-assets#exchange-asset-upload