### PR TITLE
[Fix] APIM Updates timestamp from int32 to int64

### DIFF
--- a/application_manager_v1/api/openapi.yaml
+++ b/application_manager_v1/api/openapi.yaml
@@ -1024,9 +1024,12 @@ components:
         lastUpdateTime:
           description: The timestamp (in milliseconds) when the artifact was last
             updated.
+          format: int64
+          nullable: true
           type: integer
         createTime:
           description: The creation timestamp (in milliseconds); may be null.
+          format: int64
           nullable: true
           type: integer
         name:
@@ -1109,6 +1112,7 @@ components:
         endOfSupportDate:
           description: The timestamp (in milliseconds) representing the end-of-support
             date.
+          format: int64
           type: integer
       type: object
     DeploymentInfo_muleVersion:

--- a/application_manager_v1/docs/DeploymentArtifact.md
+++ b/application_manager_v1/docs/DeploymentArtifact.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LastUpdateTime** | Pointer to **int32** | The timestamp (in milliseconds) when the artifact was last updated. | [optional] 
-**CreateTime** | Pointer to **NullableInt32** | The creation timestamp (in milliseconds); may be null. | [optional] 
+**LastUpdateTime** | Pointer to **NullableInt64** | The timestamp (in milliseconds) when the artifact was last updated. | [optional] 
+**CreateTime** | Pointer to **NullableInt64** | The creation timestamp (in milliseconds); may be null. | [optional] 
 **Name** | Pointer to **string** | The name of the artifact. | [optional] 
 **FileName** | Pointer to **string** | The file name of the artifact. | [optional] 
 
@@ -30,20 +30,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetLastUpdateTime
 
-`func (o *DeploymentArtifact) GetLastUpdateTime() int32`
+`func (o *DeploymentArtifact) GetLastUpdateTime() int64`
 
 GetLastUpdateTime returns the LastUpdateTime field if non-nil, zero value otherwise.
 
 ### GetLastUpdateTimeOk
 
-`func (o *DeploymentArtifact) GetLastUpdateTimeOk() (*int32, bool)`
+`func (o *DeploymentArtifact) GetLastUpdateTimeOk() (*int64, bool)`
 
 GetLastUpdateTimeOk returns a tuple with the LastUpdateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetLastUpdateTime
 
-`func (o *DeploymentArtifact) SetLastUpdateTime(v int32)`
+`func (o *DeploymentArtifact) SetLastUpdateTime(v int64)`
 
 SetLastUpdateTime sets LastUpdateTime field to given value.
 
@@ -53,22 +53,32 @@ SetLastUpdateTime sets LastUpdateTime field to given value.
 
 HasLastUpdateTime returns a boolean if a field has been set.
 
+### SetLastUpdateTimeNil
+
+`func (o *DeploymentArtifact) SetLastUpdateTimeNil(b bool)`
+
+ SetLastUpdateTimeNil sets the value for LastUpdateTime to be an explicit nil
+
+### UnsetLastUpdateTime
+`func (o *DeploymentArtifact) UnsetLastUpdateTime()`
+
+UnsetLastUpdateTime ensures that no value is present for LastUpdateTime, not even an explicit nil
 ### GetCreateTime
 
-`func (o *DeploymentArtifact) GetCreateTime() int32`
+`func (o *DeploymentArtifact) GetCreateTime() int64`
 
 GetCreateTime returns the CreateTime field if non-nil, zero value otherwise.
 
 ### GetCreateTimeOk
 
-`func (o *DeploymentArtifact) GetCreateTimeOk() (*int32, bool)`
+`func (o *DeploymentArtifact) GetCreateTimeOk() (*int64, bool)`
 
 GetCreateTimeOk returns a tuple with the CreateTime field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetCreateTime
 
-`func (o *DeploymentArtifact) SetCreateTime(v int32)`
+`func (o *DeploymentArtifact) SetCreateTime(v int64)`
 
 SetCreateTime sets CreateTime field to given value.
 

--- a/application_manager_v1/docs/DeploymentMuleVersion.md
+++ b/application_manager_v1/docs/DeploymentMuleVersion.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Version** | Pointer to **string** | The Mule runtime version. | [optional] 
 **UpdateId** | Pointer to **string** | The identifier for the runtime update. | [optional] 
 **LatestUpdateId** | Pointer to **string** | The identifier for the latest runtime update. | [optional] 
-**EndOfSupportDate** | Pointer to **int32** | The timestamp (in milliseconds) representing the end-of-support date. | [optional] 
+**EndOfSupportDate** | Pointer to **int64** | The timestamp (in milliseconds) representing the end-of-support date. | [optional] 
 
 ## Methods
 
@@ -105,20 +105,20 @@ HasLatestUpdateId returns a boolean if a field has been set.
 
 ### GetEndOfSupportDate
 
-`func (o *DeploymentMuleVersion) GetEndOfSupportDate() int32`
+`func (o *DeploymentMuleVersion) GetEndOfSupportDate() int64`
 
 GetEndOfSupportDate returns the EndOfSupportDate field if non-nil, zero value otherwise.
 
 ### GetEndOfSupportDateOk
 
-`func (o *DeploymentMuleVersion) GetEndOfSupportDateOk() (*int32, bool)`
+`func (o *DeploymentMuleVersion) GetEndOfSupportDateOk() (*int64, bool)`
 
 GetEndOfSupportDateOk returns a tuple with the EndOfSupportDate field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetEndOfSupportDate
 
-`func (o *DeploymentMuleVersion) SetEndOfSupportDate(v int32)`
+`func (o *DeploymentMuleVersion) SetEndOfSupportDate(v int64)`
 
 SetEndOfSupportDate sets EndOfSupportDate field to given value.
 

--- a/application_manager_v1/model_deployment_artifact.go
+++ b/application_manager_v1/model_deployment_artifact.go
@@ -20,9 +20,9 @@ var _ MappedNullable = &DeploymentArtifact{}
 // DeploymentArtifact Details about the artifact associated with the deployment.
 type DeploymentArtifact struct {
 	// The timestamp (in milliseconds) when the artifact was last updated.
-	LastUpdateTime *int32 `json:"lastUpdateTime,omitempty"`
+	LastUpdateTime NullableInt64 `json:"lastUpdateTime,omitempty"`
 	// The creation timestamp (in milliseconds); may be null.
-	CreateTime NullableInt32 `json:"createTime,omitempty"`
+	CreateTime NullableInt64 `json:"createTime,omitempty"`
 	// The name of the artifact.
 	Name *string `json:"name,omitempty"`
 	// The file name of the artifact.
@@ -46,42 +46,52 @@ func NewDeploymentArtifactWithDefaults() *DeploymentArtifact {
 	return &this
 }
 
-// GetLastUpdateTime returns the LastUpdateTime field value if set, zero value otherwise.
-func (o *DeploymentArtifact) GetLastUpdateTime() int32 {
-	if o == nil || IsNil(o.LastUpdateTime) {
-		var ret int32
+// GetLastUpdateTime returns the LastUpdateTime field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *DeploymentArtifact) GetLastUpdateTime() int64 {
+	if o == nil || IsNil(o.LastUpdateTime.Get()) {
+		var ret int64
 		return ret
 	}
-	return *o.LastUpdateTime
+	return *o.LastUpdateTime.Get()
 }
 
 // GetLastUpdateTimeOk returns a tuple with the LastUpdateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DeploymentArtifact) GetLastUpdateTimeOk() (*int32, bool) {
-	if o == nil || IsNil(o.LastUpdateTime) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *DeploymentArtifact) GetLastUpdateTimeOk() (*int64, bool) {
+	if o == nil {
 		return nil, false
 	}
-	return o.LastUpdateTime, true
+	return o.LastUpdateTime.Get(), o.LastUpdateTime.IsSet()
 }
 
 // HasLastUpdateTime returns a boolean if a field has been set.
 func (o *DeploymentArtifact) HasLastUpdateTime() bool {
-	if o != nil && !IsNil(o.LastUpdateTime) {
+	if o != nil && o.LastUpdateTime.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetLastUpdateTime gets a reference to the given int32 and assigns it to the LastUpdateTime field.
-func (o *DeploymentArtifact) SetLastUpdateTime(v int32) {
-	o.LastUpdateTime = &v
+// SetLastUpdateTime gets a reference to the given NullableInt64 and assigns it to the LastUpdateTime field.
+func (o *DeploymentArtifact) SetLastUpdateTime(v int64) {
+	o.LastUpdateTime.Set(&v)
+}
+// SetLastUpdateTimeNil sets the value for LastUpdateTime to be an explicit nil
+func (o *DeploymentArtifact) SetLastUpdateTimeNil() {
+	o.LastUpdateTime.Set(nil)
+}
+
+// UnsetLastUpdateTime ensures that no value is present for LastUpdateTime, not even an explicit nil
+func (o *DeploymentArtifact) UnsetLastUpdateTime() {
+	o.LastUpdateTime.Unset()
 }
 
 // GetCreateTime returns the CreateTime field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *DeploymentArtifact) GetCreateTime() int32 {
+func (o *DeploymentArtifact) GetCreateTime() int64 {
 	if o == nil || IsNil(o.CreateTime.Get()) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.CreateTime.Get()
@@ -90,7 +100,7 @@ func (o *DeploymentArtifact) GetCreateTime() int32 {
 // GetCreateTimeOk returns a tuple with the CreateTime field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *DeploymentArtifact) GetCreateTimeOk() (*int32, bool) {
+func (o *DeploymentArtifact) GetCreateTimeOk() (*int64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -106,8 +116,8 @@ func (o *DeploymentArtifact) HasCreateTime() bool {
 	return false
 }
 
-// SetCreateTime gets a reference to the given NullableInt32 and assigns it to the CreateTime field.
-func (o *DeploymentArtifact) SetCreateTime(v int32) {
+// SetCreateTime gets a reference to the given NullableInt64 and assigns it to the CreateTime field.
+func (o *DeploymentArtifact) SetCreateTime(v int64) {
 	o.CreateTime.Set(&v)
 }
 // SetCreateTimeNil sets the value for CreateTime to be an explicit nil
@@ -194,8 +204,8 @@ func (o DeploymentArtifact) MarshalJSON() ([]byte, error) {
 
 func (o DeploymentArtifact) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.LastUpdateTime) {
-		toSerialize["lastUpdateTime"] = o.LastUpdateTime
+	if o.LastUpdateTime.IsSet() {
+		toSerialize["lastUpdateTime"] = o.LastUpdateTime.Get()
 	}
 	if o.CreateTime.IsSet() {
 		toSerialize["createTime"] = o.CreateTime.Get()

--- a/application_manager_v1/model_deployment_mule_version.go
+++ b/application_manager_v1/model_deployment_mule_version.go
@@ -26,7 +26,7 @@ type DeploymentMuleVersion struct {
 	// The identifier for the latest runtime update.
 	LatestUpdateId *string `json:"latestUpdateId,omitempty"`
 	// The timestamp (in milliseconds) representing the end-of-support date.
-	EndOfSupportDate *int32 `json:"endOfSupportDate,omitempty"`
+	EndOfSupportDate *int64 `json:"endOfSupportDate,omitempty"`
 }
 
 // NewDeploymentMuleVersion instantiates a new DeploymentMuleVersion object
@@ -143,9 +143,9 @@ func (o *DeploymentMuleVersion) SetLatestUpdateId(v string) {
 }
 
 // GetEndOfSupportDate returns the EndOfSupportDate field value if set, zero value otherwise.
-func (o *DeploymentMuleVersion) GetEndOfSupportDate() int32 {
+func (o *DeploymentMuleVersion) GetEndOfSupportDate() int64 {
 	if o == nil || IsNil(o.EndOfSupportDate) {
-		var ret int32
+		var ret int64
 		return ret
 	}
 	return *o.EndOfSupportDate
@@ -153,7 +153,7 @@ func (o *DeploymentMuleVersion) GetEndOfSupportDate() int32 {
 
 // GetEndOfSupportDateOk returns a tuple with the EndOfSupportDate field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *DeploymentMuleVersion) GetEndOfSupportDateOk() (*int32, bool) {
+func (o *DeploymentMuleVersion) GetEndOfSupportDateOk() (*int64, bool) {
 	if o == nil || IsNil(o.EndOfSupportDate) {
 		return nil, false
 	}
@@ -169,8 +169,8 @@ func (o *DeploymentMuleVersion) HasEndOfSupportDate() bool {
 	return false
 }
 
-// SetEndOfSupportDate gets a reference to the given int32 and assigns it to the EndOfSupportDate field.
-func (o *DeploymentMuleVersion) SetEndOfSupportDate(v int32) {
+// SetEndOfSupportDate gets a reference to the given int64 and assigns it to the EndOfSupportDate field.
+func (o *DeploymentMuleVersion) SetEndOfSupportDate(v int64) {
 	o.EndOfSupportDate = &v
 }
 


### PR DESCRIPTION
Fixes format issue with timestamp format for the following attributes:
* artifact lastUpdateTime
* artifact createTime
* mule_version endOfSupportDate