### PR TITLE
release: regenerate exchange_assets client (asset-required fix)

### DIFF
--- a/apim_tier/.openapi-generator/FILES
+++ b/apim_tier/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 .travis.yml
 README.md
 api/openapi.yaml
@@ -29,5 +28,4 @@ model_sla_tier_audit_date.go
 model_sla_tier_post_body.go
 model_sla_tier_put_body.go
 response.go
-test/api_default_test.go
 utils.go

--- a/exchange_assets/api/openapi.yaml
+++ b/exchange_assets/api/openapi.yaml
@@ -854,7 +854,6 @@ components:
           title: assetLink
           type: string
       required:
-      - asset
       - assetId
       - classifier
       - groupId

--- a/exchange_assets/api_default.go
+++ b/exchange_assets/api_default.go
@@ -510,10 +510,10 @@ type DefaultAPIAssetsPostRequest struct {
 	name *string
 	classifier *string
 	groupId *string
-	asset *os.File
 	xAllowedApiSpecFormats *string
 	apiVersion *string
 	main *string
+	asset *os.File
 	dependencies *string
 	originalFormatVersion *string
 	metadata *string
@@ -563,12 +563,6 @@ func (r DefaultAPIAssetsPostRequest) GroupId(groupId string) DefaultAPIAssetsPos
 	return r
 }
 
-// The asset file. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. Maximum size of 5 MB. This field must be the last field of the multipart.
-func (r DefaultAPIAssetsPostRequest) Asset(asset *os.File) DefaultAPIAssetsPostRequest {
-	r.asset = asset
-	return r
-}
-
 // Specify API Spec formats that assets are allowed to use
 func (r DefaultAPIAssetsPostRequest) XAllowedApiSpecFormats(xAllowedApiSpecFormats string) DefaultAPIAssetsPostRequest {
 	r.xAllowedApiSpecFormats = &xAllowedApiSpecFormats
@@ -584,6 +578,12 @@ func (r DefaultAPIAssetsPostRequest) ApiVersion(apiVersion string) DefaultAPIAss
 // The main file of the asset. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;.
 func (r DefaultAPIAssetsPostRequest) Main(main string) DefaultAPIAssetsPostRequest {
 	r.main = &main
+	return r
+}
+
+// The asset file. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. Maximum size of 5 MB. This field must be the last field of the multipart.
+func (r DefaultAPIAssetsPostRequest) Asset(asset *os.File) DefaultAPIAssetsPostRequest {
+	r.asset = asset
 	return r
 }
 
@@ -676,9 +676,6 @@ func (a *DefaultAPIService) AssetsPostExecute(r DefaultAPIAssetsPostRequest) (*P
 	}
 	if r.groupId == nil {
 		return localVarReturnValue, nil, reportError("groupId is required and must be specified")
-	}
-	if r.asset == nil {
-		return localVarReturnValue, nil, reportError("asset is required and must be specified")
 	}
 
 	// to determine the Content-Type header

--- a/exchange_assets/docs/DefaultAPI.md
+++ b/exchange_assets/docs/DefaultAPI.md
@@ -313,7 +313,7 @@ Name | Type | Description  | Notes
 
 ## AssetsPost
 
-> PostAssetResponse AssetsPost(ctx).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).GroupId(groupId).Asset(asset).XAllowedApiSpecFormats(xAllowedApiSpecFormats).ApiVersion(apiVersion).Main(main).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
+> PostAssetResponse AssetsPost(ctx).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).GroupId(groupId).XAllowedApiSpecFormats(xAllowedApiSpecFormats).ApiVersion(apiVersion).Main(main).Asset(asset).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
 
 Create a new asset
 
@@ -339,10 +339,10 @@ func main() {
 	name := "name_example" // string | The visible name of the asset
 	classifier := "classifier_example" // string | The type of the asset to be created
 	groupId := "groupId_example" // string | The id of the business group the asset will belong to
-	asset := os.NewFile(1234, "some_file") // *os.File | The asset file. Required for \\\"raml\\\", \\\"raml-fragment\\\", \\\"oas\\\" and \\\"wsdl\\\". Maximum size of 5 MB. This field must be the last field of the multipart.
 	xAllowedApiSpecFormats := "xAllowedApiSpecFormats_example" // string | Specify API Spec formats that assets are allowed to use (optional)
 	apiVersion := "apiVersion_example" // string | The product version of API assets. Required for \\\"raml\\\", \\\"oas\\\", \\\"wsdl\\\" and \\\"http\\\" assets (optional)
 	main := "main_example" // string | The main file of the asset. Required for \\\"raml\\\", \\\"raml-fragment\\\", \\\"oas\\\" and \\\"wsdl\\\". (optional)
+	asset := os.NewFile(1234, "some_file") // *os.File | The asset file. Required for \\\"raml\\\", \\\"raml-fragment\\\", \\\"oas\\\" and \\\"wsdl\\\". Maximum size of 5 MB. This field must be the last field of the multipart. (optional)
 	dependencies := "dependencies_example" // string | Required for \\\"api-group\\\" classifier only, They are APIs included in it, as a JSON array of objects. Because the field must be of String type, the stringified value of the JSON array must be passed as parameter. (optional)
 	originalFormatVersion := "originalFormatVersion_example" // string | The version of the format of the api specification. ie ‘2.0’ for OAS 2.0 (optional)
 	metadata := "metadata_example" // string | A design center object describing asset projectId, branchId and commitId. Because the field must be of String type, the stringified value of the JSON object must be passed as parameter. (optional)
@@ -351,7 +351,7 @@ func main() {
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
-	resp, r, err := apiClient.DefaultAPI.AssetsPost(context.Background()).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).GroupId(groupId).Asset(asset).XAllowedApiSpecFormats(xAllowedApiSpecFormats).ApiVersion(apiVersion).Main(main).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
+	resp, r, err := apiClient.DefaultAPI.AssetsPost(context.Background()).XStrictPackage(xStrictPackage).OrganizationId(organizationId).AssetId(assetId).Version(version).Name(name).Classifier(classifier).GroupId(groupId).XAllowedApiSpecFormats(xAllowedApiSpecFormats).ApiVersion(apiVersion).Main(main).Asset(asset).Dependencies(dependencies).OriginalFormatVersion(originalFormatVersion).Metadata(metadata).Tags(tags).AssetLink(assetLink).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.AssetsPost``: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -379,10 +379,10 @@ Name | Type | Description  | Notes
  **name** | **string** | The visible name of the asset | 
  **classifier** | **string** | The type of the asset to be created | 
  **groupId** | **string** | The id of the business group the asset will belong to | 
- **asset** | ***os.File** | The asset file. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. Maximum size of 5 MB. This field must be the last field of the multipart. | 
  **xAllowedApiSpecFormats** | **string** | Specify API Spec formats that assets are allowed to use | 
  **apiVersion** | **string** | The product version of API assets. Required for \\\&quot;raml\\\&quot;, \\\&quot;oas\\\&quot;, \\\&quot;wsdl\\\&quot; and \\\&quot;http\\\&quot; assets | 
  **main** | **string** | The main file of the asset. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. | 
+ **asset** | ***os.File** | The asset file. Required for \\\&quot;raml\\\&quot;, \\\&quot;raml-fragment\\\&quot;, \\\&quot;oas\\\&quot; and \\\&quot;wsdl\\\&quot;. Maximum size of 5 MB. This field must be the last field of the multipart. | 
  **dependencies** | **string** | Required for \\\&quot;api-group\\\&quot; classifier only, They are APIs included in it, as a JSON array of objects. Because the field must be of String type, the stringified value of the JSON array must be passed as parameter. | 
  **originalFormatVersion** | **string** | The version of the format of the api specification. ie ‘2.0’ for OAS 2.0 | 
  **metadata** | **string** | A design center object describing asset projectId, branchId and commitId. Because the field must be of String type, the stringified value of the JSON object must be passed as parameter. | 


### PR DESCRIPTION
## Summary

- Regenerates `exchange_assets` Go client module from the updated OAS3 spec. The `asset` (binary file upload) field is no longer marked universally required, so the generated client now accepts http/custom/mule-application flows that supply an `assetLink` instead of an uploaded file.

## Module

- `exchange_assets/` — regenerated; client-side `assetIsRequired` reportError removed.

## Related

- Generator PRs: mulesoft-anypoint/anypoint-automation-client-generator#79 (spec fix), #80 (dev → master)
- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#58

## Release plan

- [ ] Merge this PR.
- [ ] Tag the module: `exchange_assets/v0.0.4`.
- [ ] Provider switches: `go mod edit -dropreplace … && go get exchange_assets@v0.0.4`.