### PR TITLE
Release: connected_app owner_user_id on PATCH (v1.2.0)

### DIFF
--- a/connected_app/api/openapi.yaml
+++ b/connected_app/api/openapi.yaml
@@ -498,6 +498,11 @@ components:
             example: true
             title: enabled
             type: boolean
+          owner_user_id:
+            description: User id of the connected app owner. Set to transfer ownership.
+            example: 9exb9686-4e35-81e0-45ac-8c83662480c0
+            title: ownerUserId
+            type: string
         type: object
       title: connectedAppPatchExt
     scopeCore:

--- a/connected_app/docs/ConnectedAppPatchExt.md
+++ b/connected_app/docs/ConnectedAppPatchExt.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **ClientId** | Pointer to **string** |  | [optional] 
 **ClientSecret** | Pointer to **string** |  | [optional] 
 **Enabled** | Pointer to **bool** |  | [optional] 
+**OwnerUserId** | Pointer to **string** | User id of the connected app owner. Set to transfer ownership. | [optional] 
 
 ## Methods
 
@@ -283,6 +284,31 @@ SetEnabled sets Enabled field to given value.
 `func (o *ConnectedAppPatchExt) HasEnabled() bool`
 
 HasEnabled returns a boolean if a field has been set.
+
+### GetOwnerUserId
+
+`func (o *ConnectedAppPatchExt) GetOwnerUserId() string`
+
+GetOwnerUserId returns the OwnerUserId field if non-nil, zero value otherwise.
+
+### GetOwnerUserIdOk
+
+`func (o *ConnectedAppPatchExt) GetOwnerUserIdOk() (*string, bool)`
+
+GetOwnerUserIdOk returns a tuple with the OwnerUserId field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetOwnerUserId
+
+`func (o *ConnectedAppPatchExt) SetOwnerUserId(v string)`
+
+SetOwnerUserId sets OwnerUserId field to given value.
+
+### HasOwnerUserId
+
+`func (o *ConnectedAppPatchExt) HasOwnerUserId() bool`
+
+HasOwnerUserId returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/connected_app/model_connected_app_patch_ext.go
+++ b/connected_app/model_connected_app_patch_ext.go
@@ -30,6 +30,8 @@ type ConnectedAppPatchExt struct {
 	ClientId *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 	Enabled *bool `json:"enabled,omitempty"`
+	// User id of the connected app owner. Set to transfer ownership.
+	OwnerUserId *string `json:"owner_user_id,omitempty"`
 }
 
 // NewConnectedAppPatchExt instantiates a new ConnectedAppPatchExt object
@@ -369,6 +371,38 @@ func (o *ConnectedAppPatchExt) SetEnabled(v bool) {
 	o.Enabled = &v
 }
 
+// GetOwnerUserId returns the OwnerUserId field value if set, zero value otherwise.
+func (o *ConnectedAppPatchExt) GetOwnerUserId() string {
+	if o == nil || IsNil(o.OwnerUserId) {
+		var ret string
+		return ret
+	}
+	return *o.OwnerUserId
+}
+
+// GetOwnerUserIdOk returns a tuple with the OwnerUserId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConnectedAppPatchExt) GetOwnerUserIdOk() (*string, bool) {
+	if o == nil || IsNil(o.OwnerUserId) {
+		return nil, false
+	}
+	return o.OwnerUserId, true
+}
+
+// HasOwnerUserId returns a boolean if a field has been set.
+func (o *ConnectedAppPatchExt) HasOwnerUserId() bool {
+	if o != nil && !IsNil(o.OwnerUserId) {
+		return true
+	}
+
+	return false
+}
+
+// SetOwnerUserId gets a reference to the given string and assigns it to the OwnerUserId field.
+func (o *ConnectedAppPatchExt) SetOwnerUserId(v string) {
+	o.OwnerUserId = &v
+}
+
 func (o ConnectedAppPatchExt) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -408,6 +442,9 @@ func (o ConnectedAppPatchExt) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Enabled) {
 		toSerialize["enabled"] = o.Enabled
+	}
+	if !IsNil(o.OwnerUserId) {
+		toSerialize["owner_user_id"] = o.OwnerUserId
 	}
 	return toSerialize, nil
 }


### PR DESCRIPTION
## Summary

Promote pipeline-generated `dev` to `master` so `connected_app` module can be tagged.

- Adds `OwnerUserId` field to `ConnectedAppPatchExt` (additive, non-breaking).
- Driven by generator PR mulesoft-anypoint/anypoint-automation-client-generator#82.

## Related

- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#52

## After merge

- Tag `connected_app/v1.2.0` on master (minor bump: additive field).
- Provider PR `feature/connected-app-owner` will switch from `replace` → `v1.2.0` and open against `dev`.