### PR TITLE
release: apim_policy outbound CRUD (proposed apim_policy/v0.3.0)

### DIFF
--- a/apim_policy/README.md
+++ b/apim_policy/README.md
@@ -78,16 +78,23 @@ All URIs are relative to *https://anypoint.mulesoft.com/apimanager*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*DefaultAPI* | [**DeleteApimOutboundPolicy**](docs/DefaultAPI.md#deleteapimoutboundpolicy) | **Delete** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId} | Delete a specific api manager instance outbound policy.
 *DefaultAPI* | [**DeleteApimPolicy**](docs/DefaultAPI.md#deleteapimpolicy) | **Delete** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId} | Delete a specific api manager instance policy.
+*DefaultAPI* | [**DisableApimOutboundPolicy**](docs/DefaultAPI.md#disableapimoutboundpolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/disable | Disable a specific api manager instance outbound policy.
 *DefaultAPI* | [**DisableApimPolicy**](docs/DefaultAPI.md#disableapimpolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId}/disable | Disable a specific api manager instance policy.
+*DefaultAPI* | [**EnableApimOutboundPolicy**](docs/DefaultAPI.md#enableapimoutboundpolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/enable | Enable a specific api manager instance outbound policy.
 *DefaultAPI* | [**EnableApimPolicy**](docs/DefaultAPI.md#enableapimpolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId}/enable | Enable a specific api manager instance policy.
+*DefaultAPI* | [**GetApimOutboundPolicies**](docs/DefaultAPI.md#getapimoutboundpolicies) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies | Retrieve all of api manager instance outbound policies.
+*DefaultAPI* | [**GetApimOutboundPolicy**](docs/DefaultAPI.md#getapimoutboundpolicy) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId} | Retrieve a specific api manager instance outbound policy.
 *DefaultAPI* | [**GetApimPolicies**](docs/DefaultAPI.md#getapimpolicies) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies | Retrieve all of api manager instance policies.
 *DefaultAPI* | [**GetApimPolicy**](docs/DefaultAPI.md#getapimpolicy) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId} | Retrieve a specific api manager instance policy.
 *DefaultAPI* | [**GetOrgAutomatedPolicies**](docs/DefaultAPI.md#getorgautomatedpolicies) | **Get** /api/v1/organizations/{orgId}/automated-policies | Retrieve all automated policies of a given organization
 *DefaultAPI* | [**GetOrgCustomPolicyTemplates**](docs/DefaultAPI.md#getorgcustompolicytemplates) | **Get** /api/v1/organizations/{orgId}/custom-policy-templates | Retrieve all or part of custom policy templates of a given organization
 *DefaultAPI* | [**GetOrgExchangePolicyTemplateDetails**](docs/DefaultAPI.md#getorgexchangepolicytemplatedetails) | **Get** /xapi/v1/organizations/{orgId}/exchange-policy-templates/{groupId}/{assetId}/{assetVersion} | Retrieve details of exchange policy template of a given organization
 *DefaultAPI* | [**GetOrgExchangePolicyTemplates**](docs/DefaultAPI.md#getorgexchangepolicytemplates) | **Get** /xapi/v1/organizations/{orgId}/exchange-policy-templates | Retrieve all or part of exchange policy templates of a given organization
+*DefaultAPI* | [**PatchApimOutboundPolicy**](docs/DefaultAPI.md#patchapimoutboundpolicy) | **Patch** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId} | Update a specific api manager instance outbound policy.
 *DefaultAPI* | [**PatchApimPolicy**](docs/DefaultAPI.md#patchapimpolicy) | **Patch** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId} | Update a specific api manager instance policy.
+*DefaultAPI* | [**PostApimOutboundPolicy**](docs/DefaultAPI.md#postapimoutboundpolicy) | **Post** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies | Create an api manager instance outbound policy.
 *DefaultAPI* | [**PostApimPolicy**](docs/DefaultAPI.md#postapimpolicy) | **Post** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies | Create an api manager instance policy.
 
 

--- a/apim_policy/api/openapi.yaml
+++ b/apim_policy/api/openapi.yaml
@@ -657,6 +657,381 @@ paths:
                 $ref: '#/components/schemas/ApimPolicy'
           description: enable specific api manager policy
       summary: Enable a specific api manager instance policy.
+  /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies:
+    get:
+      description: Retrieve all of api manager instance outbound policies in a given
+        organization and environment.
+      operationId: GetApimOutboundPolicies
+      parameters:
+      - description: The organization Id
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The environment Id
+        explode: false
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance Id
+        explode: false
+        in: path
+        name: apiId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: true
+        in: query
+        name: fullInfo
+        required: false
+        schema:
+          default: false
+          type: boolean
+        style: form
+      responses:
+        "401":
+          description: Access token is missing or invalid
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrgAutomatedPolicies_404_response'
+          description: resource not found
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApimPolicyCollection'
+          description: list api manager outbound policies
+      summary: Retrieve all of api manager instance outbound policies.
+    post:
+      description: Create an api manager instance outbound policy in a given organization
+        and environment.
+      operationId: PostApimOutboundPolicy
+      parameters:
+      - description: The organization Id
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The environment Id
+        explode: false
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance Id
+        explode: false
+        in: path
+        name: apiId
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApimPolicyBody'
+        description: outbound policy content
+      responses:
+        "401":
+          description: Access token is missing or invalid
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrgAutomatedPolicies_404_response'
+          description: resource not found
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApimPolicy'
+          description: create api manager outbound policy
+      summary: Create an api manager instance outbound policy.
+  /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}:
+    delete:
+      description: Delete a specific api manager instance outbound policy in a given
+        organization and environment.
+      operationId: DeleteApimOutboundPolicy
+      parameters:
+      - description: The organization Id
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The environment Id
+        explode: false
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance Id
+        explode: false
+        in: path
+        name: apiId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance outbound policy Id
+        explode: false
+        in: path
+        name: apiPolicyId
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "401":
+          description: Access token is missing or invalid
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrgAutomatedPolicies_404_response'
+          description: resource not found
+        "204":
+          description: delete specific api manager outbound policy
+      summary: Delete a specific api manager instance outbound policy.
+    get:
+      description: Retrieve a specific api manager instance outbound policy in a given
+        organization and environment.
+      operationId: GetApimOutboundPolicy
+      parameters:
+      - description: The organization Id
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The environment Id
+        explode: false
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance Id
+        explode: false
+        in: path
+        name: apiId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance outbound policy Id
+        explode: false
+        in: path
+        name: apiPolicyId
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "401":
+          description: Access token is missing or invalid
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrgAutomatedPolicies_404_response'
+          description: resource not found
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApimPolicy'
+          description: get specific api manager outbound policy
+      summary: Retrieve a specific api manager instance outbound policy.
+    patch:
+      description: Update a specific api manager instance outbound policy in a given
+        organization and environment.
+      operationId: PatchApimOutboundPolicy
+      parameters:
+      - description: The organization Id
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The environment Id
+        explode: false
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance Id
+        explode: false
+        in: path
+        name: apiId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance outbound policy Id
+        explode: false
+        in: path
+        name: apiPolicyId
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApimPolicyPatchBody'
+        description: outbound policy content
+      responses:
+        "401":
+          description: Access token is missing or invalid
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrgAutomatedPolicies_404_response'
+          description: resource not found
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApimPolicy'
+          description: patch specific api manager outbound policy
+      summary: Update a specific api manager instance outbound policy.
+  /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/disable:
+    post:
+      description: Disable a specific api manager instance outbound policy in a given
+        organization and environment.
+      operationId: DisableApimOutboundPolicy
+      parameters:
+      - description: The organization Id
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The environment Id
+        explode: false
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance Id
+        explode: false
+        in: path
+        name: apiId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance outbound policy Id
+        explode: false
+        in: path
+        name: apiPolicyId
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "401":
+          description: Access token is missing or invalid
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrgAutomatedPolicies_404_response'
+          description: resource not found
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApimPolicy'
+          description: disable specific api manager outbound policy
+      summary: Disable a specific api manager instance outbound policy.
+  /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/enable:
+    post:
+      description: Enable a specific api manager instance outbound policy in a given
+        organization and environment.
+      operationId: EnableApimOutboundPolicy
+      parameters:
+      - description: The organization Id
+        explode: false
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The environment Id
+        explode: false
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance Id
+        explode: false
+        in: path
+        name: apiId
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The api manager instance outbound policy Id
+        explode: false
+        in: path
+        name: apiPolicyId
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "401":
+          description: Access token is missing or invalid
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOrgAutomatedPolicies_404_response'
+          description: resource not found
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApimPolicy'
+          description: enable specific api manager outbound policy
+      summary: Enable a specific api manager instance outbound policy.
 components:
   responses:
     UnauthorizedError:
@@ -731,6 +1106,44 @@ components:
           schema:
             $ref: '#/components/schemas/ApimPolicy'
       description: enable specific api manager policy
+    SuccessGetApimOutboundPolicies:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApimPolicyCollection'
+      description: list api manager outbound policies
+    SuccessPostApimOutboundPolicy:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApimPolicy'
+      description: create api manager outbound policy
+    SuccessGetApimOutboundPolicy:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApimPolicy'
+      description: get specific api manager outbound policy
+    SuccessPatchApimOutboundPolicy:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApimPolicy'
+      description: patch specific api manager outbound policy
+    SuccessDeleteApimOutboundPolicy:
+      description: delete specific api manager outbound policy
+    SuccessDisableApimOutboundPolicy:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApimPolicy'
+      description: disable specific api manager outbound policy
+    SuccessEnableApimOutboundPolicy:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApimPolicy'
+      description: enable specific api manager outbound policy
   schemas:
     ErrorsResponse:
       properties:

--- a/apim_policy/api_default.go
+++ b/apim_policy/api_default.go
@@ -23,6 +23,121 @@ import (
 // DefaultAPIService DefaultAPI service
 type DefaultAPIService service
 
+type DefaultAPIDeleteApimOutboundPolicyRequest struct {
+	ctx context.Context
+	ApiService *DefaultAPIService
+	orgId string
+	envId string
+	apiId string
+	apiPolicyId string
+}
+
+func (r DefaultAPIDeleteApimOutboundPolicyRequest) Execute() (*http.Response, error) {
+	return r.ApiService.DeleteApimOutboundPolicyExecute(r)
+}
+
+/*
+DeleteApimOutboundPolicy Delete a specific api manager instance outbound policy.
+
+Delete a specific api manager instance outbound policy in a given organization and environment.
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param orgId The organization Id
+ @param envId The environment Id
+ @param apiId The api manager instance Id
+ @param apiPolicyId The api manager instance outbound policy Id
+ @return DefaultAPIDeleteApimOutboundPolicyRequest
+*/
+func (a *DefaultAPIService) DeleteApimOutboundPolicy(ctx context.Context, orgId string, envId string, apiId string, apiPolicyId string) DefaultAPIDeleteApimOutboundPolicyRequest {
+	return DefaultAPIDeleteApimOutboundPolicyRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: orgId,
+		envId: envId,
+		apiId: apiId,
+		apiPolicyId: apiPolicyId,
+	}
+}
+
+// Execute executes the request
+func (a *DefaultAPIService) DeleteApimOutboundPolicyExecute(r DefaultAPIDeleteApimOutboundPolicyRequest) (*http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodDelete
+		localVarPostBody     interface{}
+		formFiles            []formFile
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultAPIService.DeleteApimOutboundPolicy")
+	if err != nil {
+		return nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiPolicyId"+"}", url.PathEscape(parameterValueToString(r.apiPolicyId, "apiPolicyId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v GetOrgAutomatedPolicies404Response
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+					newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type DefaultAPIDeleteApimPolicyRequest struct {
 	ctx context.Context
 	ApiService *DefaultAPIService
@@ -136,6 +251,132 @@ func (a *DefaultAPIService) DeleteApimPolicyExecute(r DefaultAPIDeleteApimPolicy
 	}
 
 	return localVarHTTPResponse, nil
+}
+
+type DefaultAPIDisableApimOutboundPolicyRequest struct {
+	ctx context.Context
+	ApiService *DefaultAPIService
+	orgId string
+	envId string
+	apiId string
+	apiPolicyId string
+}
+
+func (r DefaultAPIDisableApimOutboundPolicyRequest) Execute() (*ApimPolicy, *http.Response, error) {
+	return r.ApiService.DisableApimOutboundPolicyExecute(r)
+}
+
+/*
+DisableApimOutboundPolicy Disable a specific api manager instance outbound policy.
+
+Disable a specific api manager instance outbound policy in a given organization and environment.
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param orgId The organization Id
+ @param envId The environment Id
+ @param apiId The api manager instance Id
+ @param apiPolicyId The api manager instance outbound policy Id
+ @return DefaultAPIDisableApimOutboundPolicyRequest
+*/
+func (a *DefaultAPIService) DisableApimOutboundPolicy(ctx context.Context, orgId string, envId string, apiId string, apiPolicyId string) DefaultAPIDisableApimOutboundPolicyRequest {
+	return DefaultAPIDisableApimOutboundPolicyRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: orgId,
+		envId: envId,
+		apiId: apiId,
+		apiPolicyId: apiPolicyId,
+	}
+}
+
+// Execute executes the request
+//  @return ApimPolicy
+func (a *DefaultAPIService) DisableApimOutboundPolicyExecute(r DefaultAPIDisableApimOutboundPolicyRequest) (*ApimPolicy, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodPost
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *ApimPolicy
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultAPIService.DisableApimOutboundPolicy")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/disable"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiPolicyId"+"}", url.PathEscape(parameterValueToString(r.apiPolicyId, "apiPolicyId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v GetOrgAutomatedPolicies404Response
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type DefaultAPIDisableApimPolicyRequest struct {
@@ -264,6 +505,132 @@ func (a *DefaultAPIService) DisableApimPolicyExecute(r DefaultAPIDisableApimPoli
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type DefaultAPIEnableApimOutboundPolicyRequest struct {
+	ctx context.Context
+	ApiService *DefaultAPIService
+	orgId string
+	envId string
+	apiId string
+	apiPolicyId string
+}
+
+func (r DefaultAPIEnableApimOutboundPolicyRequest) Execute() (*ApimPolicy, *http.Response, error) {
+	return r.ApiService.EnableApimOutboundPolicyExecute(r)
+}
+
+/*
+EnableApimOutboundPolicy Enable a specific api manager instance outbound policy.
+
+Enable a specific api manager instance outbound policy in a given organization and environment.
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param orgId The organization Id
+ @param envId The environment Id
+ @param apiId The api manager instance Id
+ @param apiPolicyId The api manager instance outbound policy Id
+ @return DefaultAPIEnableApimOutboundPolicyRequest
+*/
+func (a *DefaultAPIService) EnableApimOutboundPolicy(ctx context.Context, orgId string, envId string, apiId string, apiPolicyId string) DefaultAPIEnableApimOutboundPolicyRequest {
+	return DefaultAPIEnableApimOutboundPolicyRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: orgId,
+		envId: envId,
+		apiId: apiId,
+		apiPolicyId: apiPolicyId,
+	}
+}
+
+// Execute executes the request
+//  @return ApimPolicy
+func (a *DefaultAPIService) EnableApimOutboundPolicyExecute(r DefaultAPIEnableApimOutboundPolicyRequest) (*ApimPolicy, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodPost
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *ApimPolicy
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultAPIService.EnableApimOutboundPolicy")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/enable"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiPolicyId"+"}", url.PathEscape(parameterValueToString(r.apiPolicyId, "apiPolicyId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v GetOrgAutomatedPolicies404Response
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type DefaultAPIEnableApimPolicyRequest struct {
 	ctx context.Context
 	ApiService *DefaultAPIService
@@ -316,6 +683,266 @@ func (a *DefaultAPIService) EnableApimPolicyExecute(r DefaultAPIEnableApimPolicy
 	}
 
 	localVarPath := localBasePath + "/xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId}/enable"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiPolicyId"+"}", url.PathEscape(parameterValueToString(r.apiPolicyId, "apiPolicyId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v GetOrgAutomatedPolicies404Response
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type DefaultAPIGetApimOutboundPoliciesRequest struct {
+	ctx context.Context
+	ApiService *DefaultAPIService
+	orgId string
+	envId string
+	apiId string
+	fullInfo *bool
+}
+
+func (r DefaultAPIGetApimOutboundPoliciesRequest) FullInfo(fullInfo bool) DefaultAPIGetApimOutboundPoliciesRequest {
+	r.fullInfo = &fullInfo
+	return r
+}
+
+func (r DefaultAPIGetApimOutboundPoliciesRequest) Execute() (*ApimPolicyCollection, *http.Response, error) {
+	return r.ApiService.GetApimOutboundPoliciesExecute(r)
+}
+
+/*
+GetApimOutboundPolicies Retrieve all of api manager instance outbound policies.
+
+Retrieve all of api manager instance outbound policies in a given organization and environment.
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param orgId The organization Id
+ @param envId The environment Id
+ @param apiId The api manager instance Id
+ @return DefaultAPIGetApimOutboundPoliciesRequest
+*/
+func (a *DefaultAPIService) GetApimOutboundPolicies(ctx context.Context, orgId string, envId string, apiId string) DefaultAPIGetApimOutboundPoliciesRequest {
+	return DefaultAPIGetApimOutboundPoliciesRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: orgId,
+		envId: envId,
+		apiId: apiId,
+	}
+}
+
+// Execute executes the request
+//  @return ApimPolicyCollection
+func (a *DefaultAPIService) GetApimOutboundPoliciesExecute(r DefaultAPIGetApimOutboundPoliciesRequest) (*ApimPolicyCollection, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *ApimPolicyCollection
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultAPIService.GetApimOutboundPolicies")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if r.fullInfo != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "fullInfo", r.fullInfo, "form", "")
+	} else {
+		var defaultValue bool = false
+		r.fullInfo = &defaultValue
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v GetOrgAutomatedPolicies404Response
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type DefaultAPIGetApimOutboundPolicyRequest struct {
+	ctx context.Context
+	ApiService *DefaultAPIService
+	orgId string
+	envId string
+	apiId string
+	apiPolicyId string
+}
+
+func (r DefaultAPIGetApimOutboundPolicyRequest) Execute() (*ApimPolicy, *http.Response, error) {
+	return r.ApiService.GetApimOutboundPolicyExecute(r)
+}
+
+/*
+GetApimOutboundPolicy Retrieve a specific api manager instance outbound policy.
+
+Retrieve a specific api manager instance outbound policy in a given organization and environment.
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param orgId The organization Id
+ @param envId The environment Id
+ @param apiId The api manager instance Id
+ @param apiPolicyId The api manager instance outbound policy Id
+ @return DefaultAPIGetApimOutboundPolicyRequest
+*/
+func (a *DefaultAPIService) GetApimOutboundPolicy(ctx context.Context, orgId string, envId string, apiId string, apiPolicyId string) DefaultAPIGetApimOutboundPolicyRequest {
+	return DefaultAPIGetApimOutboundPolicyRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: orgId,
+		envId: envId,
+		apiId: apiId,
+		apiPolicyId: apiPolicyId,
+	}
+}
+
+// Execute executes the request
+//  @return ApimPolicy
+func (a *DefaultAPIService) GetApimOutboundPolicyExecute(r DefaultAPIGetApimOutboundPolicyRequest) (*ApimPolicy, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *ApimPolicy
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultAPIService.GetApimOutboundPolicy")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
@@ -1267,6 +1894,141 @@ func (a *DefaultAPIService) GetOrgExchangePolicyTemplatesExecute(r DefaultAPIGet
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type DefaultAPIPatchApimOutboundPolicyRequest struct {
+	ctx context.Context
+	ApiService *DefaultAPIService
+	orgId string
+	envId string
+	apiId string
+	apiPolicyId string
+	body *map[string]interface{}
+}
+
+// outbound policy content
+func (r DefaultAPIPatchApimOutboundPolicyRequest) Body(body map[string]interface{}) DefaultAPIPatchApimOutboundPolicyRequest {
+	r.body = &body
+	return r
+}
+
+func (r DefaultAPIPatchApimOutboundPolicyRequest) Execute() (*ApimPolicy, *http.Response, error) {
+	return r.ApiService.PatchApimOutboundPolicyExecute(r)
+}
+
+/*
+PatchApimOutboundPolicy Update a specific api manager instance outbound policy.
+
+Update a specific api manager instance outbound policy in a given organization and environment.
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param orgId The organization Id
+ @param envId The environment Id
+ @param apiId The api manager instance Id
+ @param apiPolicyId The api manager instance outbound policy Id
+ @return DefaultAPIPatchApimOutboundPolicyRequest
+*/
+func (a *DefaultAPIService) PatchApimOutboundPolicy(ctx context.Context, orgId string, envId string, apiId string, apiPolicyId string) DefaultAPIPatchApimOutboundPolicyRequest {
+	return DefaultAPIPatchApimOutboundPolicyRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: orgId,
+		envId: envId,
+		apiId: apiId,
+		apiPolicyId: apiPolicyId,
+	}
+}
+
+// Execute executes the request
+//  @return ApimPolicy
+func (a *DefaultAPIService) PatchApimOutboundPolicyExecute(r DefaultAPIPatchApimOutboundPolicyRequest) (*ApimPolicy, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodPatch
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *ApimPolicy
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultAPIService.PatchApimOutboundPolicy")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiPolicyId"+"}", url.PathEscape(parameterValueToString(r.apiPolicyId, "apiPolicyId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.body
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v GetOrgAutomatedPolicies404Response
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type DefaultAPIPatchApimPolicyRequest struct {
 	ctx context.Context
 	ApiService *DefaultAPIService
@@ -1354,6 +2116,137 @@ func (a *DefaultAPIService) PatchApimPolicyExecute(r DefaultAPIPatchApimPolicyRe
 	}
 	// body params
 	localVarPostBody = r.body
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v GetOrgAutomatedPolicies404Response
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+					newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+					newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
+type DefaultAPIPostApimOutboundPolicyRequest struct {
+	ctx context.Context
+	ApiService *DefaultAPIService
+	orgId string
+	envId string
+	apiId string
+	apimPolicyBody *ApimPolicyBody
+}
+
+// outbound policy content
+func (r DefaultAPIPostApimOutboundPolicyRequest) ApimPolicyBody(apimPolicyBody ApimPolicyBody) DefaultAPIPostApimOutboundPolicyRequest {
+	r.apimPolicyBody = &apimPolicyBody
+	return r
+}
+
+func (r DefaultAPIPostApimOutboundPolicyRequest) Execute() (*ApimPolicy, *http.Response, error) {
+	return r.ApiService.PostApimOutboundPolicyExecute(r)
+}
+
+/*
+PostApimOutboundPolicy Create an api manager instance outbound policy.
+
+Create an api manager instance outbound policy in a given organization and environment.
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @param orgId The organization Id
+ @param envId The environment Id
+ @param apiId The api manager instance Id
+ @return DefaultAPIPostApimOutboundPolicyRequest
+*/
+func (a *DefaultAPIService) PostApimOutboundPolicy(ctx context.Context, orgId string, envId string, apiId string) DefaultAPIPostApimOutboundPolicyRequest {
+	return DefaultAPIPostApimOutboundPolicyRequest{
+		ApiService: a,
+		ctx: ctx,
+		orgId: orgId,
+		envId: envId,
+		apiId: apiId,
+	}
+}
+
+// Execute executes the request
+//  @return ApimPolicy
+func (a *DefaultAPIService) PostApimOutboundPolicyExecute(r DefaultAPIPostApimOutboundPolicyRequest) (*ApimPolicy, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodPost
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *ApimPolicy
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultAPIService.PostApimOutboundPolicy")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgId"+"}", url.PathEscape(parameterValueToString(r.orgId, "orgId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"envId"+"}", url.PathEscape(parameterValueToString(r.envId, "envId")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"apiId"+"}", url.PathEscape(parameterValueToString(r.apiId, "apiId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.apimPolicyBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/apim_policy/docs/DefaultAPI.md
+++ b/apim_policy/docs/DefaultAPI.md
@@ -4,18 +4,102 @@ All URIs are relative to *https://anypoint.mulesoft.com/apimanager*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**DeleteApimOutboundPolicy**](DefaultAPI.md#DeleteApimOutboundPolicy) | **Delete** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId} | Delete a specific api manager instance outbound policy.
 [**DeleteApimPolicy**](DefaultAPI.md#DeleteApimPolicy) | **Delete** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId} | Delete a specific api manager instance policy.
+[**DisableApimOutboundPolicy**](DefaultAPI.md#DisableApimOutboundPolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/disable | Disable a specific api manager instance outbound policy.
 [**DisableApimPolicy**](DefaultAPI.md#DisableApimPolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId}/disable | Disable a specific api manager instance policy.
+[**EnableApimOutboundPolicy**](DefaultAPI.md#EnableApimOutboundPolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId}/enable | Enable a specific api manager instance outbound policy.
 [**EnableApimPolicy**](DefaultAPI.md#EnableApimPolicy) | **Post** /xapi/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId}/enable | Enable a specific api manager instance policy.
+[**GetApimOutboundPolicies**](DefaultAPI.md#GetApimOutboundPolicies) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies | Retrieve all of api manager instance outbound policies.
+[**GetApimOutboundPolicy**](DefaultAPI.md#GetApimOutboundPolicy) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId} | Retrieve a specific api manager instance outbound policy.
 [**GetApimPolicies**](DefaultAPI.md#GetApimPolicies) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies | Retrieve all of api manager instance policies.
 [**GetApimPolicy**](DefaultAPI.md#GetApimPolicy) | **Get** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId} | Retrieve a specific api manager instance policy.
 [**GetOrgAutomatedPolicies**](DefaultAPI.md#GetOrgAutomatedPolicies) | **Get** /api/v1/organizations/{orgId}/automated-policies | Retrieve all automated policies of a given organization
 [**GetOrgCustomPolicyTemplates**](DefaultAPI.md#GetOrgCustomPolicyTemplates) | **Get** /api/v1/organizations/{orgId}/custom-policy-templates | Retrieve all or part of custom policy templates of a given organization
 [**GetOrgExchangePolicyTemplateDetails**](DefaultAPI.md#GetOrgExchangePolicyTemplateDetails) | **Get** /xapi/v1/organizations/{orgId}/exchange-policy-templates/{groupId}/{assetId}/{assetVersion} | Retrieve details of exchange policy template of a given organization
 [**GetOrgExchangePolicyTemplates**](DefaultAPI.md#GetOrgExchangePolicyTemplates) | **Get** /xapi/v1/organizations/{orgId}/exchange-policy-templates | Retrieve all or part of exchange policy templates of a given organization
+[**PatchApimOutboundPolicy**](DefaultAPI.md#PatchApimOutboundPolicy) | **Patch** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies/{apiPolicyId} | Update a specific api manager instance outbound policy.
 [**PatchApimPolicy**](DefaultAPI.md#PatchApimPolicy) | **Patch** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/{apiPolicyId} | Update a specific api manager instance policy.
+[**PostApimOutboundPolicy**](DefaultAPI.md#PostApimOutboundPolicy) | **Post** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies/outbound-policies | Create an api manager instance outbound policy.
 [**PostApimPolicy**](DefaultAPI.md#PostApimPolicy) | **Post** /api/v1/organizations/{orgId}/environments/{envId}/apis/{apiId}/policies | Create an api manager instance policy.
 
+
+
+## DeleteApimOutboundPolicy
+
+> DeleteApimOutboundPolicy(ctx, orgId, envId, apiId, apiPolicyId).Execute()
+
+Delete a specific api manager instance outbound policy.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/mulesoft-anypoint/anypoint-client-go/apim_policy"
+)
+
+func main() {
+	orgId := "orgId_example" // string | The organization Id
+	envId := "envId_example" // string | The environment Id
+	apiId := "apiId_example" // string | The api manager instance Id
+	apiPolicyId := "apiPolicyId_example" // string | The api manager instance outbound policy Id
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	r, err := apiClient.DefaultAPI.DeleteApimOutboundPolicy(context.Background(), orgId, envId, apiId, apiPolicyId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.DeleteApimOutboundPolicy``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The organization Id | 
+**envId** | **string** | The environment Id | 
+**apiId** | **string** | The api manager instance Id | 
+**apiPolicyId** | **string** | The api manager instance outbound policy Id | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiDeleteApimOutboundPolicyRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
 
 
 ## DeleteApimPolicy
@@ -80,6 +164,85 @@ Name | Type | Description  | Notes
 ### Return type
 
  (empty response body)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## DisableApimOutboundPolicy
+
+> ApimPolicy DisableApimOutboundPolicy(ctx, orgId, envId, apiId, apiPolicyId).Execute()
+
+Disable a specific api manager instance outbound policy.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/mulesoft-anypoint/anypoint-client-go/apim_policy"
+)
+
+func main() {
+	orgId := "orgId_example" // string | The organization Id
+	envId := "envId_example" // string | The environment Id
+	apiId := "apiId_example" // string | The api manager instance Id
+	apiPolicyId := "apiPolicyId_example" // string | The api manager instance outbound policy Id
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.DefaultAPI.DisableApimOutboundPolicy(context.Background(), orgId, envId, apiId, apiPolicyId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.DisableApimOutboundPolicy``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `DisableApimOutboundPolicy`: ApimPolicy
+	fmt.Fprintf(os.Stdout, "Response from `DefaultAPI.DisableApimOutboundPolicy`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The organization Id | 
+**envId** | **string** | The environment Id | 
+**apiId** | **string** | The api manager instance Id | 
+**apiPolicyId** | **string** | The api manager instance outbound policy Id | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiDisableApimOutboundPolicyRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+
+### Return type
+
+[**ApimPolicy**](ApimPolicy.md)
 
 ### Authorization
 
@@ -174,6 +337,85 @@ Name | Type | Description  | Notes
 [[Back to README]](../README.md)
 
 
+## EnableApimOutboundPolicy
+
+> ApimPolicy EnableApimOutboundPolicy(ctx, orgId, envId, apiId, apiPolicyId).Execute()
+
+Enable a specific api manager instance outbound policy.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/mulesoft-anypoint/anypoint-client-go/apim_policy"
+)
+
+func main() {
+	orgId := "orgId_example" // string | The organization Id
+	envId := "envId_example" // string | The environment Id
+	apiId := "apiId_example" // string | The api manager instance Id
+	apiPolicyId := "apiPolicyId_example" // string | The api manager instance outbound policy Id
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.DefaultAPI.EnableApimOutboundPolicy(context.Background(), orgId, envId, apiId, apiPolicyId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.EnableApimOutboundPolicy``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `EnableApimOutboundPolicy`: ApimPolicy
+	fmt.Fprintf(os.Stdout, "Response from `DefaultAPI.EnableApimOutboundPolicy`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The organization Id | 
+**envId** | **string** | The environment Id | 
+**apiId** | **string** | The api manager instance Id | 
+**apiPolicyId** | **string** | The api manager instance outbound policy Id | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiEnableApimOutboundPolicyRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+
+### Return type
+
+[**ApimPolicy**](ApimPolicy.md)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
 ## EnableApimPolicy
 
 > ApimPolicy EnableApimPolicy(ctx, orgId, envId, apiId, apiPolicyId).Execute()
@@ -226,6 +468,163 @@ Name | Type | Description  | Notes
 ### Other Parameters
 
 Other parameters are passed through a pointer to a apiEnableApimPolicyRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+
+### Return type
+
+[**ApimPolicy**](ApimPolicy.md)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## GetApimOutboundPolicies
+
+> ApimPolicyCollection GetApimOutboundPolicies(ctx, orgId, envId, apiId).FullInfo(fullInfo).Execute()
+
+Retrieve all of api manager instance outbound policies.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/mulesoft-anypoint/anypoint-client-go/apim_policy"
+)
+
+func main() {
+	orgId := "orgId_example" // string | The organization Id
+	envId := "envId_example" // string | The environment Id
+	apiId := "apiId_example" // string | The api manager instance Id
+	fullInfo := true // bool |  (optional) (default to false)
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.DefaultAPI.GetApimOutboundPolicies(context.Background(), orgId, envId, apiId).FullInfo(fullInfo).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.GetApimOutboundPolicies``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `GetApimOutboundPolicies`: ApimPolicyCollection
+	fmt.Fprintf(os.Stdout, "Response from `DefaultAPI.GetApimOutboundPolicies`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The organization Id | 
+**envId** | **string** | The environment Id | 
+**apiId** | **string** | The api manager instance Id | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetApimOutboundPoliciesRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+ **fullInfo** | **bool** |  | [default to false]
+
+### Return type
+
+[**ApimPolicyCollection**](ApimPolicyCollection.md)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## GetApimOutboundPolicy
+
+> ApimPolicy GetApimOutboundPolicy(ctx, orgId, envId, apiId, apiPolicyId).Execute()
+
+Retrieve a specific api manager instance outbound policy.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/mulesoft-anypoint/anypoint-client-go/apim_policy"
+)
+
+func main() {
+	orgId := "orgId_example" // string | The organization Id
+	envId := "envId_example" // string | The environment Id
+	apiId := "apiId_example" // string | The api manager instance Id
+	apiPolicyId := "apiPolicyId_example" // string | The api manager instance outbound policy Id
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.DefaultAPI.GetApimOutboundPolicy(context.Background(), orgId, envId, apiId, apiPolicyId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.GetApimOutboundPolicy``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `GetApimOutboundPolicy`: ApimPolicy
+	fmt.Fprintf(os.Stdout, "Response from `DefaultAPI.GetApimOutboundPolicy`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The organization Id | 
+**envId** | **string** | The environment Id | 
+**apiId** | **string** | The api manager instance Id | 
+**apiPolicyId** | **string** | The api manager instance outbound policy Id | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetApimOutboundPolicyRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
@@ -729,6 +1128,87 @@ Name | Type | Description  | Notes
 [[Back to README]](../README.md)
 
 
+## PatchApimOutboundPolicy
+
+> ApimPolicy PatchApimOutboundPolicy(ctx, orgId, envId, apiId, apiPolicyId).Body(body).Execute()
+
+Update a specific api manager instance outbound policy.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/mulesoft-anypoint/anypoint-client-go/apim_policy"
+)
+
+func main() {
+	orgId := "orgId_example" // string | The organization Id
+	envId := "envId_example" // string | The environment Id
+	apiId := "apiId_example" // string | The api manager instance Id
+	apiPolicyId := "apiPolicyId_example" // string | The api manager instance outbound policy Id
+	body := map[string]interface{}{ ... } // map[string]interface{} | outbound policy content (optional)
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.DefaultAPI.PatchApimOutboundPolicy(context.Background(), orgId, envId, apiId, apiPolicyId).Body(body).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.PatchApimOutboundPolicy``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `PatchApimOutboundPolicy`: ApimPolicy
+	fmt.Fprintf(os.Stdout, "Response from `DefaultAPI.PatchApimOutboundPolicy`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The organization Id | 
+**envId** | **string** | The environment Id | 
+**apiId** | **string** | The api manager instance Id | 
+**apiPolicyId** | **string** | The api manager instance outbound policy Id | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiPatchApimOutboundPolicyRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+ **body** | **map[string]interface{}** | outbound policy content | 
+
+### Return type
+
+[**ApimPolicy**](ApimPolicy.md)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
 ## PatchApimPolicy
 
 > ApimPolicy PatchApimPolicy(ctx, orgId, envId, apiId, apiPolicyId).Body(body).Execute()
@@ -791,6 +1271,84 @@ Name | Type | Description  | Notes
 
 
  **body** | **map[string]interface{}** | policy content | 
+
+### Return type
+
+[**ApimPolicy**](ApimPolicy.md)
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## PostApimOutboundPolicy
+
+> ApimPolicy PostApimOutboundPolicy(ctx, orgId, envId, apiId).ApimPolicyBody(apimPolicyBody).Execute()
+
+Create an api manager instance outbound policy.
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/mulesoft-anypoint/anypoint-client-go/apim_policy"
+)
+
+func main() {
+	orgId := "orgId_example" // string | The organization Id
+	envId := "envId_example" // string | The environment Id
+	apiId := "apiId_example" // string | The api manager instance Id
+	apimPolicyBody := *openapiclient.NewApimPolicyBody() // ApimPolicyBody | outbound policy content (optional)
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.DefaultAPI.PostApimOutboundPolicy(context.Background(), orgId, envId, apiId).ApimPolicyBody(apimPolicyBody).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `DefaultAPI.PostApimOutboundPolicy``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `PostApimOutboundPolicy`: ApimPolicy
+	fmt.Fprintf(os.Stdout, "Response from `DefaultAPI.PostApimOutboundPolicy`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**orgId** | **string** | The organization Id | 
+**envId** | **string** | The environment Id | 
+**apiId** | **string** | The api manager instance Id | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiPostApimOutboundPolicyRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+ **apimPolicyBody** | [**ApimPolicyBody**](ApimPolicyBody.md) | outbound policy content | 
 
 ### Return type
 


### PR DESCRIPTION
## Summary

Pipeline-generated release batch for `apim_policy` module. Adds outbound policy CRUD support.

Single feature: 7 new endpoints on the `apim_policy` module covering the outbound-policy lifecycle under `/apis/{apiId}/policies/outbound-policies` (POST list-create + GET-list + GET-one + PATCH + DELETE + enable + disable). Request/response bodies reuse the existing `ApimPolicy*` schemas — only URL paths and operationIds change.

## Affected modules

| Module | Change |
|---|---|
| `apim_policy` | + 7 outbound endpoints (`PostApimOutboundPolicy`, `GetApimOutboundPolicies`, `GetApimOutboundPolicy`, `PatchApimOutboundPolicy`, `DeleteApimOutboundPolicy`, `EnableApimOutboundPolicy`, `DisableApimOutboundPolicy`). No schema additions. **Proposed tag: `apim_policy/v0.3.0`** |

## Related

- Generator PR: mulesoft-anypoint/anypoint-automation-client-generator#85 (merged to master 2026-05-31)
- Generator release PR: mulesoft-anypoint/anypoint-automation-client-generator#86 (merged to master)
- Provider issue: mulesoft-anypoint/terraform-provider-anypoint#139
- Provider PR (draft, awaiting this tag): mulesoft-anypoint/terraform-provider-anypoint#141

## Post-merge

- [ ] Tag `apim_policy/v0.3.0` on master.
- [ ] Unblock provider PR #141: drop `replace`, `go get .../apim_policy@v0.3.0`, mark ready for review.

## Note

Pipeline diff also removes `CODEOWNERS`. Carried over from a prior pipeline batch — not introduced by this release. Flagging in case it should be restored separately.
